### PR TITLE
Implementing `eslint-plugin-boundaries`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,8 +6,18 @@
     "boundaries/elements": [
       {
         "mode": "full",
-        "type": "application",
-        "pattern": ["src/application/**/*"]
+        "type": "use-cases",
+        "pattern": ["src/application/use-cases/**/*"]
+      },
+      {
+        "mode": "full",
+        "type": "service-interfaces",
+        "pattern": ["src/application/services/**/*"]
+      },
+      {
+        "mode": "full",
+        "type": "repository-interfaces",
+        "pattern": ["src/application/repositories/**/*"]
       },
       {
         "mode": "full",
@@ -45,14 +55,22 @@
           },
           {
             "from": "interface-adapters",
-            "allow": ["application", "entities"]
+            "allow": ["use-cases", "entities"]
           },
           {
             "from": "infrastructure",
-            "allow": ["application", "entities"]
+            "allow": ["service-interfaces", "repository-interfaces", "entities"]
           },
           {
-            "from": "application",
+            "from": "use-cases",
+            "allow": ["entities"]
+          },
+          {
+            "from": "service-interfaces",
+            "allow": ["entities"]
+          },
+          {
+            "from": "repository-interfaces",
             "allow": ["entities"]
           },
           {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,66 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": ["next/core-web-vitals"],
+  "plugins": ["boundaries"],
+  "settings": {
+    "boundaries/include": ["src/**/*", "app/**/*"],
+    "boundaries/elements": [
+      {
+        "mode": "full",
+        "type": "application",
+        "pattern": ["src/application/**/*"]
+      },
+      {
+        "mode": "full",
+        "type": "infrastructure",
+        "pattern": ["src/infrastructure/**/*"]
+      },
+      {
+        "mode": "full",
+        "type": "interface-adapters",
+        "pattern": ["src/interface-adapters/**/*"]
+      },
+      {
+        "mode": "full",
+        "type": "entities",
+        "pattern": ["src/entities/**/*"]
+      },
+      {
+        "mode": "full",
+        "type": "web",
+        "pattern": ["app/**/*"]
+      }
+    ]
+  },
+  "rules": {
+    "boundaries/no-unknown": "error",
+    "boundaries/no-unknown-files": "error",
+    "boundaries/element-types": [
+      "error",
+      {
+        "default": "disallow",
+        "rules": [
+          {
+            "from": "web",
+            "allow": ["web", "interface-adapters", "entities"]
+          },
+          {
+            "from": "interface-adapters",
+            "allow": ["application", "entities"]
+          },
+          {
+            "from": "infrastructure",
+            "allow": ["application", "entities"]
+          },
+          {
+            "from": "application",
+            "allow": ["entities"]
+          },
+          {
+            "from": "entities",
+            "allow": ["entities"]
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,6 +6,16 @@
     "boundaries/elements": [
       {
         "mode": "full",
+        "type": "web",
+        "pattern": ["app/**/*"]
+      },
+      {
+        "mode": "full",
+        "type": "interface-adapters",
+        "pattern": ["src/interface-adapters/**/*"]
+      },
+      {
+        "mode": "full",
         "type": "use-cases",
         "pattern": ["src/application/use-cases/**/*"]
       },
@@ -21,23 +31,13 @@
       },
       {
         "mode": "full",
-        "type": "infrastructure",
-        "pattern": ["src/infrastructure/**/*"]
-      },
-      {
-        "mode": "full",
-        "type": "interface-adapters",
-        "pattern": ["src/interface-adapters/**/*"]
-      },
-      {
-        "mode": "full",
         "type": "entities",
         "pattern": ["src/entities/**/*"]
       },
       {
         "mode": "full",
-        "type": "web",
-        "pattern": ["app/**/*"]
+        "type": "infrastructure",
+        "pattern": ["src/infrastructure/**/*"]
       }
     ]
   },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,30 +1,31 @@
-import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
-import { captureException, startSpan } from "@sentry/nextjs";
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
 
-import { SESSION_COOKIE } from "@/config";
+import { SESSION_COOKIE } from '@/config';
+import { getInjection } from '@/di/container';
 import {
   AuthenticationError,
   UnauthenticatedError,
-} from "@/src/entities/errors/auth";
-import { Todo } from "@/src/entities/models/todo";
-import { getTodosForUserController } from "@/src/interface-adapters/controllers/todos/get-todos-for-user.controller";
+} from '@/src/entities/errors/auth';
+import { Todo } from '@/src/entities/models/todo';
+import { getTodosForUserController } from '@/src/interface-adapters/controllers/todos/get-todos-for-user.controller';
 import {
   Card,
   CardContent,
   CardHeader,
   CardTitle,
-} from "./_components/ui/card";
-import { Separator } from "./_components/ui/separator";
-import { UserMenu } from "./_components/ui/user-menu";
-import { CreateTodo } from "./add-todo";
-import { Todos } from "./todos";
+} from './_components/ui/card';
+import { Separator } from './_components/ui/separator';
+import { UserMenu } from './_components/ui/user-menu';
+import { CreateTodo } from './add-todo';
+import { Todos } from './todos';
 
 async function getTodos(sessionId: string | undefined) {
-  return await startSpan(
+  const instrumentationService = getInjection('IInstrumentationService');
+  return await instrumentationService.startSpan(
     {
-      name: "getTodos",
-      op: "function.nextjs",
+      name: 'getTodos',
+      op: 'function.nextjs',
     },
     async () => {
       try {
@@ -34,12 +35,13 @@ async function getTodos(sessionId: string | undefined) {
           err instanceof UnauthenticatedError ||
           err instanceof AuthenticationError
         ) {
-          redirect("/sign-in");
+          redirect('/sign-in');
         }
-        captureException(err);
+        const crashReporterService = getInjection('ICrashReporterService');
+        crashReporterService.report(err);
         throw err;
       }
-    },
+    }
   );
 }
 
@@ -54,13 +56,13 @@ export default async function Home() {
   }
 
   return (
-    <Card className="w-full max-w-lg">
-      <CardHeader className="flex flex-row items-center">
-        <CardTitle className="flex-1">TODOs</CardTitle>
+    <Card className='w-full max-w-lg'>
+      <CardHeader className='flex flex-row items-center'>
+        <CardTitle className='flex-1'>TODOs</CardTitle>
         <UserMenu />
       </CardHeader>
       <Separator />
-      <CardContent className="flex flex-col p-6 gap-4">
+      <CardContent className='flex flex-col p-6 gap-4'>
         <CreateTodo />
         <Todos todos={todos} />
       </CardContent>

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "drizzle-kit": "^0.23.1",
         "eslint": "^8",
         "eslint-config-next": "14.2.5",
+        "eslint-plugin-boundaries": "^4.2.2",
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
         "typescript": "^5"
@@ -6407,6 +6408,24 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-boundaries": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-boundaries/-/eslint-plugin-boundaries-4.2.2.tgz",
+      "integrity": "sha512-cjwpZqkCXgfz953bc74uDetOtGVxwgMgNZ7hAKi6Oxck+x4oY6Z/9DzgPqAYhtQdSNHFVg+vhft/lSL+snPMQg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "4.1.2",
+        "eslint-import-resolver-node": "0.3.9",
+        "eslint-module-utils": "2.8.1",
+        "micromatch": "4.0.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
       }
     },
     "node_modules/eslint-plugin-import": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "drizzle-kit": "^0.23.1",
     "eslint": "^8",
     "eslint-config-next": "14.2.5",
+    "eslint-plugin-boundaries": "^4.2.2",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -2,11 +2,11 @@
 // The config you add here will be used whenever a users loads a page in their browser.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
-import * as Sentry from "@sentry/nextjs";
+import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  enabled: process.env.NODE_ENV !== "test",
+  enabled: process.env.NODE_ENV !== 'test',
 
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 1,

--- a/src/application/repositories/users.repository.interface.ts
+++ b/src/application/repositories/users.repository.interface.ts
@@ -1,5 +1,5 @@
-import type { User } from "@/src/entities/models/user";
-import { ITransaction } from "@/src/application/services/transaction-manager.service.interface";
+import type { User } from '@/src/entities/models/user';
+import type { ITransaction } from '@/src/entities/models/transaction.interface';
 
 export interface IUsersRepository {
   getUser(id: string): Promise<User | undefined>;

--- a/src/application/services/crash-reporter.service.interface.ts
+++ b/src/application/services/crash-reporter.service.interface.ts
@@ -1,3 +1,3 @@
 export interface ICrashReporterService {
-  report(error: Error): string;
+  report(error: any): string;
 }

--- a/src/application/services/instrumentation.service.interface.ts
+++ b/src/application/services/instrumentation.service.interface.ts
@@ -3,4 +3,9 @@ export interface IInstrumentationService {
     options: { name: string; op?: string; attributes?: Record<string, any> },
     callback: () => T
   ): T;
+  instrumentServerAction<T>(
+    name: string,
+    options: Record<string, any>,
+    callback: () => T
+  ): Promise<T>;
 }

--- a/src/application/services/transaction-manager.service.interface.ts
+++ b/src/application/services/transaction-manager.service.interface.ts
@@ -1,10 +1,8 @@
-export interface ITransaction {
-  rollback: () => void;
-}
+import type { ITransaction } from '@/src/entities/models/transaction.interface';
 
 export interface ITransactionManagerService {
   startTransaction<T>(
     clb: (tx: ITransaction) => Promise<T>,
-    parent?: ITransaction,
+    parent?: ITransaction
   ): Promise<T>;
 }

--- a/src/application/use-cases/auth/sign-in.use-case.ts
+++ b/src/application/use-cases/auth/sign-in.use-case.ts
@@ -1,42 +1,45 @@
-import { verify } from "@node-rs/argon2";
-import { startSpan } from "@sentry/nextjs";
+import { verify } from '@node-rs/argon2';
 
-import { getInjection } from "@/di/container";
-import { AuthenticationError } from "@/src/entities/errors/auth";
-import { Cookie } from "@/src/entities/models/cookie";
-import { Session } from "@/src/entities/models/session";
+import { getInjection } from '@/di/container';
+import { AuthenticationError } from '@/src/entities/errors/auth';
+import { Cookie } from '@/src/entities/models/cookie';
+import { Session } from '@/src/entities/models/session';
 
 export function signInUseCase(input: {
   username: string;
   password: string;
 }): Promise<{ session: Session; cookie: Cookie }> {
-  return startSpan({ name: "signIn Use Case", op: "function" }, async () => {
-    const authenticationService = getInjection("IAuthenticationService");
-    const usersRepository = getInjection("IUsersRepository");
+  const instrumentationService = getInjection('IInstrumentationService');
+  return instrumentationService.startSpan(
+    { name: 'signIn Use Case', op: 'function' },
+    async () => {
+      const authenticationService = getInjection('IAuthenticationService');
+      const usersRepository = getInjection('IUsersRepository');
 
-    const existingUser = await usersRepository.getUserByUsername(
-      input.username,
-    );
+      const existingUser = await usersRepository.getUserByUsername(
+        input.username
+      );
 
-    if (!existingUser) {
-      throw new AuthenticationError("User does not exist");
+      if (!existingUser) {
+        throw new AuthenticationError('User does not exist');
+      }
+
+      const validPassword = await instrumentationService.startSpan(
+        { name: 'verify password hash', op: 'function' },
+        () =>
+          verify(existingUser.password_hash, input.password, {
+            memoryCost: 19456,
+            timeCost: 2,
+            outputLen: 32,
+            parallelism: 1,
+          })
+      );
+
+      if (!validPassword) {
+        throw new AuthenticationError('Incorrect username or password');
+      }
+
+      return await authenticationService.createSession(existingUser);
     }
-
-    const validPassword = await startSpan(
-      { name: "verify password hash", op: "function" },
-      () =>
-        verify(existingUser.password_hash, input.password, {
-          memoryCost: 19456,
-          timeCost: 2,
-          outputLen: 32,
-          parallelism: 1,
-        }),
-    );
-
-    if (!validPassword) {
-      throw new AuthenticationError("Incorrect username or password");
-    }
-
-    return await authenticationService.createSession(existingUser);
-  });
+  );
 }

--- a/src/application/use-cases/auth/sign-out.use-case.ts
+++ b/src/application/use-cases/auth/sign-out.use-case.ts
@@ -1,14 +1,16 @@
-import { startSpan } from "@sentry/nextjs";
-
-import { getInjection } from "@/di/container";
-import { Cookie } from "@/src/entities/models/cookie";
+import { getInjection } from '@/di/container';
+import { Cookie } from '@/src/entities/models/cookie';
 
 export function signOutUseCase(
-  sessionId: string,
+  sessionId: string
 ): Promise<{ blankCookie: Cookie }> {
-  return startSpan({ name: "signOut Use Case", op: "function" }, async () => {
-    const authenticationService = getInjection("IAuthenticationService");
+  const instrumentationService = getInjection('IInstrumentationService');
+  return instrumentationService.startSpan(
+    { name: 'signOut Use Case', op: 'function' },
+    async () => {
+      const authenticationService = getInjection('IAuthenticationService');
 
-    return await authenticationService.invalidateSession(sessionId);
-  });
+      return await authenticationService.invalidateSession(sessionId);
+    }
+  );
 }

--- a/src/application/use-cases/auth/sign-up.use-case.ts
+++ b/src/application/use-cases/auth/sign-up.use-case.ts
@@ -1,11 +1,10 @@
-import { hash } from "@node-rs/argon2";
-import { startSpan } from "@sentry/nextjs";
+import { hash } from '@node-rs/argon2';
 
-import { getInjection } from "@/di/container";
-import { AuthenticationError } from "@/src/entities/errors/auth";
-import { Cookie } from "@/src/entities/models/cookie";
-import { Session } from "@/src/entities/models/session";
-import { User } from "@/src/entities/models/user";
+import { getInjection } from '@/di/container';
+import { AuthenticationError } from '@/src/entities/errors/auth';
+import { Cookie } from '@/src/entities/models/cookie';
+import { Session } from '@/src/entities/models/session';
+import { User } from '@/src/entities/models/user';
 
 export function signUpUseCase(input: {
   username: string;
@@ -13,45 +12,50 @@ export function signUpUseCase(input: {
 }): Promise<{
   session: Session;
   cookie: Cookie;
-  user: Pick<User, "id" | "username">;
+  user: Pick<User, 'id' | 'username'>;
 }> {
-  return startSpan({ name: "signUp Use Case", op: "function" }, async () => {
-    const usersRepository = getInjection("IUsersRepository");
-    const user = await usersRepository.getUserByUsername(input.username);
-    if (user) {
-      throw new AuthenticationError("Username taken");
+  const instrumentationService = getInjection('IInstrumentationService');
+  return instrumentationService.startSpan(
+    { name: 'signUp Use Case', op: 'function' },
+    async () => {
+      const usersRepository = getInjection('IUsersRepository');
+      const user = await usersRepository.getUserByUsername(input.username);
+      if (user) {
+        throw new AuthenticationError('Username taken');
+      }
+
+      const passwordHash = await instrumentationService.startSpan(
+        { name: 'hash password', op: 'function' },
+        () =>
+          hash(input.password, {
+            memoryCost: 19456,
+            timeCost: 2,
+            outputLen: 32,
+            parallelism: 1,
+          })
+      );
+
+      const authenticationService = getInjection('IAuthenticationService');
+      const userId = authenticationService.generateUserId();
+
+      const newUser = await usersRepository.createUser({
+        id: userId,
+        username: input.username,
+        password_hash: passwordHash,
+      });
+
+      const { cookie, session } = await authenticationService.createSession(
+        newUser
+      );
+
+      return {
+        cookie,
+        session,
+        user: {
+          id: newUser.id,
+          username: newUser.username,
+        },
+      };
     }
-
-    const passwordHash = await startSpan(
-      { name: "hash password", op: "function" },
-      () =>
-        hash(input.password, {
-          memoryCost: 19456,
-          timeCost: 2,
-          outputLen: 32,
-          parallelism: 1,
-        }),
-    );
-
-    const authenticationService = getInjection("IAuthenticationService");
-    const userId = authenticationService.generateUserId();
-
-    const newUser = await usersRepository.createUser({
-      id: userId,
-      username: input.username,
-      password_hash: passwordHash,
-    });
-
-    const { cookie, session } =
-      await authenticationService.createSession(newUser);
-
-    return {
-      cookie,
-      session,
-      user: {
-        id: newUser.id,
-        username: newUser.username,
-      },
-    };
-  });
+  );
 }

--- a/src/application/use-cases/todos/create-todo.use-case.ts
+++ b/src/application/use-cases/todos/create-todo.use-case.ts
@@ -1,26 +1,25 @@
-import { startSpan } from "@sentry/nextjs";
-
-import { getInjection } from "@/di/container";
-import { InputParseError } from "@/src/entities/errors/common";
-import type { Todo } from "@/src/entities/models/todo";
+import { getInjection } from '@/di/container';
+import { InputParseError } from '@/src/entities/errors/common';
+import type { Todo } from '@/src/entities/models/todo';
 
 export function createTodoUseCase(
   input: {
     todo: string;
   },
   userId: string,
-  tx?: any,
+  tx?: any
 ): Promise<Todo> {
-  return startSpan(
-    { name: "createTodo Use Case", op: "function" },
+  const instrumentationService = getInjection('IInstrumentationService');
+  return instrumentationService.startSpan(
+    { name: 'createTodo Use Case', op: 'function' },
     async () => {
-      const todosRepository = getInjection("ITodosRepository");
+      const todosRepository = getInjection('ITodosRepository');
 
       // HINT: this is where you'd do authorization checks - is this user authorized to create a todo
       // for example: free users are allowed only 5 todos, throw an UnauthorizedError if more than 5
 
       if (input.todo.length < 4) {
-        throw new InputParseError("Todo must be at least 4 chars");
+        throw new InputParseError('Todo must be at least 4 chars');
       }
 
       const newTodo = await todosRepository.createTodo(
@@ -29,10 +28,10 @@ export function createTodoUseCase(
           userId,
           completed: false,
         },
-        tx,
+        tx
       );
 
       return newTodo;
-    },
+    }
   );
 }

--- a/src/application/use-cases/todos/delete-todo.use-case.ts
+++ b/src/application/use-cases/todos/delete-todo.use-case.ts
@@ -1,36 +1,35 @@
-import { startSpan } from "@sentry/nextjs";
-
-import { getInjection } from "@/di/container";
-import { UnauthorizedError } from "@/src/entities/errors/auth";
-import { NotFoundError } from "@/src/entities/errors/common";
-import type { Todo } from "@/src/entities/models/todo";
-import { ITransaction } from "@/src/application/services/transaction-manager.service.interface";
+import { getInjection } from '@/di/container';
+import { UnauthorizedError } from '@/src/entities/errors/auth';
+import { NotFoundError } from '@/src/entities/errors/common';
+import type { Todo } from '@/src/entities/models/todo';
+import type { ITransaction } from '@/src/entities/models/transaction.interface';
 
 export function deleteTodoUseCase(
   input: {
     todoId: number;
   },
   userId: string,
-  tx?: ITransaction,
+  tx?: ITransaction
 ): Promise<Todo> {
-  return startSpan(
-    { name: "deleteTodo Use Case", op: "function" },
+  const instrumentationService = getInjection('IInstrumentationService');
+  return instrumentationService.startSpan(
+    { name: 'deleteTodo Use Case', op: 'function' },
     async () => {
-      const todosRepository = getInjection("ITodosRepository");
+      const todosRepository = getInjection('ITodosRepository');
 
       const todo = await todosRepository.getTodo(input.todoId);
 
       if (!todo) {
-        throw new NotFoundError("Todo does not exist");
+        throw new NotFoundError('Todo does not exist');
       }
 
       if (todo.userId !== userId) {
-        throw new UnauthorizedError("Cannot delete todo. Reason: unauthorized");
+        throw new UnauthorizedError('Cannot delete todo. Reason: unauthorized');
       }
 
       await todosRepository.deleteTodo(todo.id, tx);
 
       return todo;
-    },
+    }
   );
 }

--- a/src/application/use-cases/todos/get-todos-for-user.use-case.ts
+++ b/src/application/use-cases/todos/get-todos-for-user.use-case.ts
@@ -1,15 +1,14 @@
-import { startSpan } from "@sentry/nextjs";
-
-import { getInjection } from "@/di/container";
-import type { Todo } from "@/src/entities/models/todo";
+import { getInjection } from '@/di/container';
+import type { Todo } from '@/src/entities/models/todo';
 
 export function getTodosForUserUseCase(userId: string): Promise<Todo[]> {
-  return startSpan(
-    { name: "getTodosForUser UseCase", op: "function" },
+  const instrumentationService = getInjection('IInstrumentationService');
+  return instrumentationService.startSpan(
+    { name: 'getTodosForUser UseCase', op: 'function' },
     async () => {
-      const todosRepository = getInjection("ITodosRepository");
+      const todosRepository = getInjection('ITodosRepository');
 
       return await todosRepository.getTodosForUser(userId);
-    },
+    }
   );
 }

--- a/src/application/use-cases/todos/toggle-todo.use-case.ts
+++ b/src/application/use-cases/todos/toggle-todo.use-case.ts
@@ -1,31 +1,30 @@
-import { startSpan } from "@sentry/nextjs";
-
-import { getInjection } from "@/di/container";
-import { UnauthorizedError } from "@/src/entities/errors/auth";
-import { NotFoundError } from "@/src/entities/errors/common";
-import type { Todo } from "@/src/entities/models/todo";
-import { ITransaction } from "@/src/application/services/transaction-manager.service.interface";
+import { getInjection } from '@/di/container';
+import { UnauthorizedError } from '@/src/entities/errors/auth';
+import { NotFoundError } from '@/src/entities/errors/common';
+import type { Todo } from '@/src/entities/models/todo';
+import type { ITransaction } from '@/src/entities/models/transaction.interface';
 
 export function toggleTodoUseCase(
   input: {
     todoId: number;
   },
   userId: string,
-  tx?: ITransaction,
+  tx?: ITransaction
 ): Promise<Todo> {
-  return startSpan(
-    { name: "toggleTodo Use Case", op: "function" },
+  const instrumentationService = getInjection('IInstrumentationService');
+  return instrumentationService.startSpan(
+    { name: 'toggleTodo Use Case', op: 'function' },
     async () => {
-      const todosRepository = getInjection("ITodosRepository");
+      const todosRepository = getInjection('ITodosRepository');
 
       const todo = await todosRepository.getTodo(input.todoId);
 
       if (!todo) {
-        throw new NotFoundError("Todo does not exist");
+        throw new NotFoundError('Todo does not exist');
       }
 
       if (todo.userId !== userId) {
-        throw new UnauthorizedError("Cannot toggle todo. Reason: unauthorized");
+        throw new UnauthorizedError('Cannot toggle todo. Reason: unauthorized');
       }
 
       const updatedTodo = await todosRepository.updateTodo(
@@ -33,10 +32,10 @@ export function toggleTodoUseCase(
         {
           completed: !todo.completed,
         },
-        tx,
+        tx
       );
 
       return updatedTodo;
-    },
+    }
   );
 }

--- a/src/entities/models/transaction.interface.ts
+++ b/src/entities/models/transaction.interface.ts
@@ -1,0 +1,3 @@
+export interface ITransaction {
+  rollback: () => void;
+}

--- a/src/infrastructure/repositories/todos.repository.ts
+++ b/src/infrastructure/repositories/todos.repository.ts
@@ -1,99 +1,111 @@
-import { eq } from "drizzle-orm";
-import { injectable } from "inversify";
-import { startSpan, captureException } from "@sentry/nextjs";
+import { eq } from 'drizzle-orm';
+import { inject, injectable } from 'inversify';
 
-import { db, Transaction } from "@/drizzle";
-import { todos } from "@/drizzle/schema";
-import { ITodosRepository } from "@/src/application/repositories/todos.repository.interface";
-import { DatabaseOperationError } from "@/src/entities/errors/common";
-import { TodoInsert, Todo } from "@/src/entities/models/todo";
+import { db, Transaction } from '@/drizzle';
+import { todos } from '@/drizzle/schema';
+import { ITodosRepository } from '@/src/application/repositories/todos.repository.interface';
+import { DatabaseOperationError } from '@/src/entities/errors/common';
+import { TodoInsert, Todo } from '@/src/entities/models/todo';
+import type { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
+import { DI_SYMBOLS } from '@/di/types';
+import type { ICrashReporterService } from '@/src/application/services/crash-reporter.service.interface';
 
 @injectable()
 export class TodosRepository implements ITodosRepository {
+  constructor(
+    @inject(DI_SYMBOLS.IInstrumentationService)
+    private readonly instrumentationService: IInstrumentationService,
+    @inject(DI_SYMBOLS.ICrashReporterService)
+    private readonly crashReporterService: ICrashReporterService
+  ) {}
+
   async createTodo(todo: TodoInsert, tx?: Transaction): Promise<Todo> {
     const invoker = tx ?? db;
 
-    return await startSpan(
-      { name: "TodosRepository > createTodo" },
+    return await this.instrumentationService.startSpan(
+      { name: 'TodosRepository > createTodo' },
       async () => {
         try {
           const query = invoker.insert(todos).values(todo).returning();
 
-          const [created] = await startSpan(
+          const [created] = await this.instrumentationService.startSpan(
             {
               name: query.toSQL().sql,
-              op: "db.query",
-              attributes: { "db.system": "sqlite" },
+              op: 'db.query',
+              attributes: { 'db.system': 'sqlite' },
             },
-            () => query.execute(),
+            () => query.execute()
           );
 
           if (created) {
             return created;
           } else {
-            throw new DatabaseOperationError("Cannot create todo");
+            throw new DatabaseOperationError('Cannot create todo');
           }
         } catch (err) {
-          captureException(err, { data: todo });
+          this.crashReporterService.report(err);
           throw err; // TODO: convert to Entities error
         }
-      },
+      }
     );
   }
 
   async getTodo(id: number): Promise<Todo | undefined> {
-    return await startSpan({ name: "TodosRepository > getTodo" }, async () => {
-      try {
-        const query = db.query.todos.findFirst({
-          where: eq(todos.id, id),
-        });
+    return await this.instrumentationService.startSpan(
+      { name: 'TodosRepository > getTodo' },
+      async () => {
+        try {
+          const query = db.query.todos.findFirst({
+            where: eq(todos.id, id),
+          });
 
-        const todo = await startSpan(
-          {
-            name: query.toSQL().sql,
-            op: "db.query",
-            attributes: { "db.system": "sqlite" },
-          },
-          () => query.execute(),
-        );
+          const todo = await this.instrumentationService.startSpan(
+            {
+              name: query.toSQL().sql,
+              op: 'db.query',
+              attributes: { 'db.system': 'sqlite' },
+            },
+            () => query.execute()
+          );
 
-        return todo;
-      } catch (err) {
-        captureException(err);
-        throw err; // TODO: convert to Entities error
+          return todo;
+        } catch (err) {
+          this.crashReporterService.report(err);
+          throw err; // TODO: convert to Entities error
+        }
       }
-    });
+    );
   }
 
   async getTodosForUser(userId: string): Promise<Todo[]> {
-    return await startSpan(
-      { name: "TodosRepository > getTodosForUser" },
+    return await this.instrumentationService.startSpan(
+      { name: 'TodosRepository > getTodosForUser' },
       async () => {
         try {
           const query = db.query.todos.findMany({
             where: eq(todos.userId, userId),
           });
 
-          const usersTodos = await startSpan(
+          const usersTodos = await this.instrumentationService.startSpan(
             {
               name: query.toSQL().sql,
-              op: "db.query",
-              attributes: { "db.system": "sqlite" },
+              op: 'db.query',
+              attributes: { 'db.system': 'sqlite' },
             },
-            () => query.execute(),
+            () => query.execute()
           );
           return usersTodos;
         } catch (err) {
-          captureException(err);
+          this.crashReporterService.report(err);
           throw err; // TODO: convert to Entities error
         }
-      },
+      }
     );
   }
 
   async updateTodo(id: number, input: Partial<TodoInsert>): Promise<Todo> {
-    return await startSpan(
-      { name: "TodosRepository > updateTodo" },
+    return await this.instrumentationService.startSpan(
+      { name: 'TodosRepository > updateTodo' },
       async () => {
         try {
           const query = db
@@ -102,42 +114,48 @@ export class TodosRepository implements ITodosRepository {
             .where(eq(todos.id, id))
             .returning();
 
-          const [updated] = await startSpan(
+          const [updated] = await this.instrumentationService.startSpan(
             {
               name: query.toSQL().sql,
-              op: "db.query",
-              attributes: { "db.system": "sqlite" },
+              op: 'db.query',
+              attributes: { 'db.system': 'sqlite' },
             },
-            () => query.execute(),
+            () => query.execute()
           );
           return updated;
         } catch (err) {
-          captureException(err);
+          this.crashReporterService.report(err);
           throw err; // TODO: convert to Entities error
         }
-      },
+      }
     );
   }
 
   async deleteTodo(id: number, tx?: Transaction): Promise<void> {
     const invoker = tx ?? db;
 
-    await startSpan({ name: "TodosRepository > deleteTodo" }, async () => {
-      try {
-        const query = invoker.delete(todos).where(eq(todos.id, id)).returning();
+    await this.instrumentationService.startSpan(
+      { name: 'TodosRepository > deleteTodo' },
+      async () => {
+        try {
+          const query = invoker
+            .delete(todos)
+            .where(eq(todos.id, id))
+            .returning();
 
-        await startSpan(
-          {
-            name: query.toSQL().sql,
-            op: "db.query",
-            attributes: { "db.system": "sqlite" },
-          },
-          () => query.execute(),
-        );
-      } catch (err) {
-        captureException(err);
-        throw err; // TODO: convert to Entities error
+          await this.instrumentationService.startSpan(
+            {
+              name: query.toSQL().sql,
+              op: 'db.query',
+              attributes: { 'db.system': 'sqlite' },
+            },
+            () => query.execute()
+          );
+        } catch (err) {
+          this.crashReporterService.report(err);
+          throw err; // TODO: convert to Entities error
+        }
       }
-    });
+    );
   }
 }

--- a/src/infrastructure/repositories/users.repository.ts
+++ b/src/infrastructure/repositories/users.repository.ts
@@ -1,90 +1,101 @@
-import { eq } from "drizzle-orm";
-import { injectable } from "inversify";
-import { startSpan, captureException } from "@sentry/nextjs";
+import { eq } from 'drizzle-orm';
+import { inject, injectable } from 'inversify';
 
-import { db } from "@/drizzle";
-import { users } from "@/drizzle/schema";
-import { IUsersRepository } from "@/src/application/repositories/users.repository.interface";
-import { DatabaseOperationError } from "@/src/entities/errors/common";
-import { User } from "@/src/entities/models/user";
+import { db } from '@/drizzle';
+import { DI_SYMBOLS } from '@/di/types';
+import { users } from '@/drizzle/schema';
+import { IUsersRepository } from '@/src/application/repositories/users.repository.interface';
+import { DatabaseOperationError } from '@/src/entities/errors/common';
+import { User } from '@/src/entities/models/user';
+import type { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
+import type { ICrashReporterService } from '@/src/application/services/crash-reporter.service.interface';
 
 @injectable()
 export class UsersRepository implements IUsersRepository {
+  constructor(
+    @inject(DI_SYMBOLS.IInstrumentationService)
+    private readonly instrumentationService: IInstrumentationService,
+    @inject(DI_SYMBOLS.ICrashReporterService)
+    private readonly crashReporterService: ICrashReporterService
+  ) {}
   async getUser(id: string): Promise<User | undefined> {
-    return await startSpan({ name: "UsersRepository > getUser" }, async () => {
-      try {
-        const query = db.query.users.findFirst({
-          where: eq(users.id, id),
-        });
+    return await this.instrumentationService.startSpan(
+      { name: 'UsersRepository > getUser' },
+      async () => {
+        try {
+          const query = db.query.users.findFirst({
+            where: eq(users.id, id),
+          });
 
-        const user = await startSpan(
-          {
-            name: query.toSQL().sql,
-            op: "db.query",
-            attributes: { "db.system": "sqlite" },
-          },
-          () => query.execute(),
-        );
+          const user = await this.instrumentationService.startSpan(
+            {
+              name: query.toSQL().sql,
+              op: 'db.query',
+              attributes: { 'db.system': 'sqlite' },
+            },
+            () => query.execute()
+          );
 
-        return user;
-      } catch (err) {
-        captureException(err);
-        throw err; // TODO: convert to Entities error
+          return user;
+        } catch (err) {
+          this.crashReporterService.report(err);
+          throw err; // TODO: convert to Entities error
+        }
       }
-    });
+    );
   }
   async getUserByUsername(username: string): Promise<User | undefined> {
-    return await startSpan(
-      { name: "UsersRepository > getUserByUsername" },
+    return await this.instrumentationService.startSpan(
+      { name: 'UsersRepository > getUserByUsername' },
       async () => {
         try {
           const query = db.query.users.findFirst({
             where: eq(users.username, username),
           });
 
-          const user = await startSpan(
+          const user = await this.instrumentationService.startSpan(
             {
               name: query.toSQL().sql,
-              op: "db.query",
-              attributes: { "db.system": "sqlite" },
+              op: 'db.query',
+              attributes: { 'db.system': 'sqlite' },
             },
-            () => query.execute(),
+            () => query.execute()
           );
 
           return user;
         } catch (err) {
-          captureException(err);
+          this.crashReporterService.report(err);
           throw err; // TODO: convert to Entities error
         }
-      },
+      }
     );
   }
   async createUser(input: User): Promise<User> {
-    return await startSpan(
-      { name: "UsersRepository > createUser" },
+    return await this.instrumentationService.startSpan(
+      { name: 'UsersRepository > createUser' },
       async () => {
         try {
           const query = db.insert(users).values(input).returning();
 
-          const [created] = await startSpan(
+          const [created] = await this.instrumentationService.startSpan(
             {
               name: query.toSQL().sql,
-              op: "db.query",
-              attributes: { "db.system": "sqlite" },
+              op: 'db.query',
+              attributes: { 'db.system': 'sqlite' },
             },
-            () => query.execute(),
+            () => query.execute()
           );
 
           if (created) {
             return created;
           } else {
-            throw new DatabaseOperationError("Cannot create user.");
+            throw new DatabaseOperationError('Cannot create user.');
           }
         } catch (err) {
-          captureException(err);
+          this.crashReporterService.report(err);
           throw err; // TODO: convert to Entities error
         }
-      },
+      }
     );
   }
 }

--- a/src/infrastructure/services/crash-reporter.service.mock.ts
+++ b/src/infrastructure/services/crash-reporter.service.mock.ts
@@ -4,7 +4,7 @@ import { ICrashReporterService } from '@/src/application/services/crash-reporter
 
 @injectable()
 export class MockCrashReporterService implements ICrashReporterService {
-  report(_: Error): string {
+  report(_: any): string {
     return 'errorId';
   }
 }

--- a/src/infrastructure/services/crash-reporter.service.ts
+++ b/src/infrastructure/services/crash-reporter.service.ts
@@ -5,7 +5,7 @@ import { ICrashReporterService } from '@/src/application/services/crash-reporter
 
 @injectable()
 export class CrashReporterService implements ICrashReporterService {
-  report(error: Error): string {
+  report(error: any): string {
     return Sentry.captureException(error);
   }
 }

--- a/src/infrastructure/services/instrumentation.service.mock.ts
+++ b/src/infrastructure/services/instrumentation.service.mock.ts
@@ -10,4 +10,12 @@ export class MockInstrumentationService implements IInstrumentationService {
   ): T {
     return callback();
   }
+
+  async instrumentServerAction<T>(
+    _: string,
+    __: Record<string, any>,
+    callback: () => T
+  ): Promise<T> {
+    return callback();
+  }
 }

--- a/src/infrastructure/services/instrumentation.service.ts
+++ b/src/infrastructure/services/instrumentation.service.ts
@@ -11,4 +11,12 @@ export class InstrumentationService implements IInstrumentationService {
   ): T {
     return Sentry.startSpan(options, callback);
   }
+
+  instrumentServerAction<T>(
+    name: string,
+    options: Record<string, any>,
+    callback: () => T
+  ): Promise<T> {
+    return Sentry.withServerActionInstrumentation(name, options, callback);
+  }
 }

--- a/src/infrastructure/services/transaction-manager.service.mock.ts
+++ b/src/infrastructure/services/transaction-manager.service.mock.ts
@@ -1,16 +1,14 @@
-import { injectable } from "inversify";
+import { injectable } from 'inversify';
 
-import {
-  ITransaction,
-  ITransactionManagerService,
-} from "@/src/application/services/transaction-manager.service.interface";
+import { ITransactionManagerService } from '@/src/application/services/transaction-manager.service.interface';
+import { ITransaction } from '@/src/entities/models/transaction.interface';
 
 @injectable()
 export class MockTransactionManagerService
   implements ITransactionManagerService
 {
   public startTransaction<T>(
-    clb: (tx: ITransaction) => Promise<T>,
+    clb: (tx: ITransaction) => Promise<T>
   ): Promise<T> {
     return clb({ rollback: () => {} });
   }


### PR DESCRIPTION
Implementing the [`eslint-plugin-boundaries`](https://github.com/javierbrea/eslint-plugin-boundaries) in order to get errors when breaking the layer dependency rules.

> [!NOTE]
> This PR also contains refactoring direct imports of Sentry and replacing them with the corresponding services.