### PR TITLE
Feature/use ioctopus modules feature

### DIFF
--- a/di/container.ts
+++ b/di/container.ts
@@ -4,19 +4,19 @@ import { DI_RETURN_TYPES, DI_SYMBOLS } from '@/di/types';
 
 import { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
 
-import { registerMonitoringModule } from '@/di/modules/monitoring.module';
-import { registerAuthenticationModule } from '@/di/modules/authentication.module';
-import { registerTransactionManagerModule } from '@/di/modules/database.module';
-import { registerTodosModule } from '@/di/modules/todos.module';
-import { registerUsersModule } from '@/di/modules/users.module';
+import { createMonitoringModule } from '@/di/modules/monitoring.module';
+import { createAuthenticationModule } from '@/di/modules/authentication.module';
+import { createTransactionManagerModule } from '@/di/modules/database.module';
+import { createTodosModule } from '@/di/modules/todos.module';
+import { createUsersModule } from '@/di/modules/users.module';
 
 const ApplicationContainer = createContainer();
 
-registerMonitoringModule(ApplicationContainer);
-registerTransactionManagerModule(ApplicationContainer);
-registerAuthenticationModule(ApplicationContainer);
-registerUsersModule(ApplicationContainer);
-registerTodosModule(ApplicationContainer);
+ApplicationContainer.load(Symbol('MonitoringModule'), createMonitoringModule());
+ApplicationContainer.load(Symbol('TransactionManagerModule'), createTransactionManagerModule());
+ApplicationContainer.load(Symbol('AuthenticationModule'), createAuthenticationModule());
+ApplicationContainer.load(Symbol('UsersModule'), createUsersModule());
+ApplicationContainer.load(Symbol('TodosModule'), createTodosModule());
 
 export function getInjection<K extends keyof typeof DI_SYMBOLS>(
   symbol: K

--- a/di/modules/authentication.module.ts
+++ b/di/modules/authentication.module.ts
@@ -1,4 +1,4 @@
-import { Container } from '@evyweb/ioctopus';
+import { createModule } from '@evyweb/ioctopus';
 
 import { AuthenticationService } from '@/src/infrastructure/services/authentication.service';
 import { MockAuthenticationService } from '@/src/infrastructure/services/authentication.service.mock';
@@ -13,13 +13,15 @@ import { signUpController } from '@/src/interface-adapters/controllers/auth/sign
 
 import { DI_SYMBOLS } from '@/di/types';
 
-export function registerAuthenticationModule(container: Container) {
+export function createAuthenticationModule() {
+  const authenticationModule = createModule();
+
   if (process.env.NODE_ENV === 'test') {
-    container
+    authenticationModule
       .bind(DI_SYMBOLS.IAuthenticationService)
       .toClass(MockAuthenticationService, [DI_SYMBOLS.IUsersRepository]);
   } else {
-    container
+    authenticationModule
       .bind(DI_SYMBOLS.IAuthenticationService)
       .toClass(AuthenticationService, [
         DI_SYMBOLS.IUsersRepository,
@@ -27,7 +29,7 @@ export function registerAuthenticationModule(container: Container) {
       ]);
   }
 
-  container
+  authenticationModule
     .bind(DI_SYMBOLS.ISignInUseCase)
     .toHigherOrderFunction(signInUseCase, [
       DI_SYMBOLS.IInstrumentationService,
@@ -35,14 +37,14 @@ export function registerAuthenticationModule(container: Container) {
       DI_SYMBOLS.IAuthenticationService,
     ]);
 
-  container
+  authenticationModule
     .bind(DI_SYMBOLS.ISignOutUseCase)
     .toHigherOrderFunction(signOutUseCase, [
       DI_SYMBOLS.IInstrumentationService,
       DI_SYMBOLS.IAuthenticationService,
     ]);
 
-  container
+  authenticationModule
     .bind(DI_SYMBOLS.ISignUpUseCase)
     .toHigherOrderFunction(signUpUseCase, [
       DI_SYMBOLS.IInstrumentationService,
@@ -50,14 +52,14 @@ export function registerAuthenticationModule(container: Container) {
       DI_SYMBOLS.IUsersRepository,
     ]);
 
-  container
+  authenticationModule
     .bind(DI_SYMBOLS.ISignInController)
     .toHigherOrderFunction(signInController, [
       DI_SYMBOLS.IInstrumentationService,
       DI_SYMBOLS.ISignInUseCase,
     ]);
 
-  container
+  authenticationModule
     .bind(DI_SYMBOLS.ISignOutController)
     .toHigherOrderFunction(signOutController, [
       DI_SYMBOLS.IInstrumentationService,
@@ -65,10 +67,12 @@ export function registerAuthenticationModule(container: Container) {
       DI_SYMBOLS.ISignOutUseCase,
     ]);
 
-  container
+  authenticationModule
     .bind(DI_SYMBOLS.ISignUpController)
     .toHigherOrderFunction(signUpController, [
       DI_SYMBOLS.IInstrumentationService,
       DI_SYMBOLS.ISignUpUseCase,
     ]);
+
+  return authenticationModule;
 }

--- a/di/modules/database.module.ts
+++ b/di/modules/database.module.ts
@@ -1,18 +1,22 @@
-import { Container } from '@evyweb/ioctopus';
+import { createModule } from '@evyweb/ioctopus';
 
 import { TransactionManagerService } from '@/src/infrastructure/services/transaction-manager.service';
 import { MockTransactionManagerService } from '@/src/infrastructure/services/transaction-manager.service.mock';
 
 import { DI_SYMBOLS } from '@/di/types';
 
-export function registerTransactionManagerModule(container: Container) {
+export function createTransactionManagerModule() {
+  const transactionManagerModule = createModule();
+
   if (process.env.NODE_ENV === 'test') {
-    container
+    transactionManagerModule
       .bind(DI_SYMBOLS.ITransactionManagerService)
       .toClass(MockTransactionManagerService);
   } else {
-    container
+    transactionManagerModule
       .bind(DI_SYMBOLS.ITransactionManagerService)
       .toClass(TransactionManagerService);
   }
+
+  return transactionManagerModule;
 }

--- a/di/modules/monitoring.module.ts
+++ b/di/modules/monitoring.module.ts
@@ -1,4 +1,4 @@
-import { Container } from '@evyweb/ioctopus';
+import { createModule } from '@evyweb/ioctopus';
 
 import { MockInstrumentationService } from '@/src/infrastructure/services/instrumentation.service.mock';
 import { InstrumentationService } from '@/src/infrastructure/services/instrumentation.service';
@@ -7,20 +7,24 @@ import { CrashReporterService } from '@/src/infrastructure/services/crash-report
 
 import { DI_SYMBOLS } from '@/di/types';
 
-export function registerMonitoringModule(container: Container) {
+export function createMonitoringModule() {
+  const monitoringModule = createModule();
+
   if (process.env.NODE_ENV === 'test') {
-    container
+    monitoringModule
       .bind(DI_SYMBOLS.IInstrumentationService)
       .toClass(MockInstrumentationService);
-    container
+    monitoringModule
       .bind(DI_SYMBOLS.ICrashReporterService)
       .toClass(MockCrashReporterService);
   } else {
-    container
+    monitoringModule
       .bind(DI_SYMBOLS.IInstrumentationService)
       .toClass(InstrumentationService);
-    container
+    monitoringModule
       .bind(DI_SYMBOLS.ICrashReporterService)
       .toClass(CrashReporterService);
   }
+
+  return monitoringModule;
 }

--- a/di/modules/todos.module.ts
+++ b/di/modules/todos.module.ts
@@ -1,4 +1,4 @@
-import { Container } from '@evyweb/ioctopus';
+import { createModule } from '@evyweb/ioctopus';
 
 import { MockTodosRepository } from '@/src/infrastructure/repositories/todos.repository.mock';
 import { TodosRepository } from '@/src/infrastructure/repositories/todos.repository';
@@ -15,11 +15,13 @@ import { toggleTodoController } from '@/src/interface-adapters/controllers/todos
 
 import { DI_SYMBOLS } from '@/di/types';
 
-export function registerTodosModule(container: Container) {
+export function createTodosModule() {
+  const todosModule = createModule();
+
   if (process.env.NODE_ENV === 'test') {
-    container.bind(DI_SYMBOLS.ITodosRepository).toClass(MockTodosRepository);
+    todosModule.bind(DI_SYMBOLS.ITodosRepository).toClass(MockTodosRepository);
   } else {
-    container
+    todosModule
       .bind(DI_SYMBOLS.ITodosRepository)
       .toClass(TodosRepository, [
         DI_SYMBOLS.IInstrumentationService,
@@ -27,35 +29,35 @@ export function registerTodosModule(container: Container) {
       ]);
   }
 
-  container
+  todosModule
     .bind(DI_SYMBOLS.ICreateTodoUseCase)
     .toHigherOrderFunction(createTodoUseCase, [
       DI_SYMBOLS.IInstrumentationService,
       DI_SYMBOLS.ITodosRepository,
     ]);
 
-  container
+  todosModule
     .bind(DI_SYMBOLS.IDeleteTodoUseCase)
     .toHigherOrderFunction(deleteTodoUseCase, [
       DI_SYMBOLS.IInstrumentationService,
       DI_SYMBOLS.ITodosRepository,
     ]);
 
-  container
+  todosModule
     .bind(DI_SYMBOLS.IGetTodosForUserUseCase)
     .toHigherOrderFunction(getTodosForUserUseCase, [
       DI_SYMBOLS.IInstrumentationService,
       DI_SYMBOLS.ITodosRepository,
     ]);
 
-  container
+  todosModule
     .bind(DI_SYMBOLS.IToggleTodoUseCase)
     .toHigherOrderFunction(toggleTodoUseCase, [
       DI_SYMBOLS.IInstrumentationService,
       DI_SYMBOLS.ITodosRepository,
     ]);
 
-  container
+  todosModule
     .bind(DI_SYMBOLS.IBulkUpdateController)
     .toHigherOrderFunction(bulkUpdateController, [
       DI_SYMBOLS.IInstrumentationService,
@@ -65,7 +67,7 @@ export function registerTodosModule(container: Container) {
       DI_SYMBOLS.IDeleteTodoUseCase,
     ]);
 
-  container
+  todosModule
     .bind(DI_SYMBOLS.ICreateTodoController)
     .toHigherOrderFunction(createTodoController, [
       DI_SYMBOLS.IInstrumentationService,
@@ -74,7 +76,7 @@ export function registerTodosModule(container: Container) {
       DI_SYMBOLS.ICreateTodoUseCase,
     ]);
 
-  container
+  todosModule
     .bind(DI_SYMBOLS.IGetTodosForUserController)
     .toHigherOrderFunction(getTodosForUserController, [
       DI_SYMBOLS.IInstrumentationService,
@@ -82,11 +84,13 @@ export function registerTodosModule(container: Container) {
       DI_SYMBOLS.IGetTodosForUserUseCase,
     ]);
 
-  container
+  todosModule
     .bind(DI_SYMBOLS.IToggleTodoController)
     .toHigherOrderFunction(toggleTodoController, [
       DI_SYMBOLS.IInstrumentationService,
       DI_SYMBOLS.IAuthenticationService,
       DI_SYMBOLS.IToggleTodoUseCase,
     ]);
+
+  return todosModule;
 }

--- a/di/modules/users.module.ts
+++ b/di/modules/users.module.ts
@@ -1,19 +1,23 @@
-import { Container } from '@evyweb/ioctopus';
+import { createModule } from '@evyweb/ioctopus';
 
 import { MockUsersRepository } from '@/src/infrastructure/repositories/users.repository.mock';
 import { UsersRepository } from '@/src/infrastructure/repositories/users.repository';
 
 import { DI_SYMBOLS } from '@/di/types';
 
-export function registerUsersModule(container: Container) {
+export function createUsersModule() {
+  const usersModule = createModule();
+
   if (process.env.NODE_ENV === 'test') {
-    container.bind(DI_SYMBOLS.IUsersRepository).toClass(MockUsersRepository);
+    usersModule.bind(DI_SYMBOLS.IUsersRepository).toClass(MockUsersRepository);
   } else {
-    container
+    usersModule
       .bind(DI_SYMBOLS.IUsersRepository)
       .toClass(UsersRepository, [
         DI_SYMBOLS.IInstrumentationService,
         DI_SYMBOLS.ICrashReporterService,
       ]);
   }
+
+  return usersModule;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "nextjs-clean-architecture",
       "version": "0.1.0",
       "dependencies": {
-        "@evyweb/ioctopus": "^0.3.0",
+        "@evyweb/ioctopus": "^1.1.0",
         "@libsql/client": "^0.9.0",
         "@lucia-auth/adapter-drizzle": "^1.1.0",
         "@radix-ui/react-avatar": "^1.1.0",
@@ -1318,9 +1318,9 @@
       }
     },
     "node_modules/@evyweb/ioctopus": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@evyweb/ioctopus/-/ioctopus-0.3.0.tgz",
-      "integrity": "sha512-ch2CfRsaCWvQcGptp60j0OYCY4Fo1USMiNtlWoN+KtEkBgWr/BFD/dj7W6vFF5RXbSmcZLVUXBKS/7dUpCGc5Q=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@evyweb/ioctopus/-/ioctopus-1.1.0.tgz",
+      "integrity": "sha512-L5cvnz7Pw9pmmUBq4KKyTi6e25l6Km6ekG/0wjqFjwPQvqjmmixxPCtzs8EG0ciWkPeQoLcossVBWd34tKqzNQ=="
     },
     "node_modules/@floating-ui/core": {
       "version": "1.6.5",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@evyweb/ioctopus": "^0.3.0",
+    "@evyweb/ioctopus": "^1.1.0",
     "@libsql/client": "^0.9.0",
     "@lucia-auth/adapter-drizzle": "^1.1.0",
     "@radix-ui/react-avatar": "^1.1.0",


### PR DESCRIPTION
Ioctopus is now supporting modules to register dependencies: https://github.com/Evyweb/ioctopus?tab=readme-ov-file#modules

This PR is:
- updating ioctopus version to the last v1.1.0.
- replacing the manual creation of the modules by those provided by ioctopus with the createModule function.

It is also safer because it can detect potential circular dependencies.

I hope that it can help.